### PR TITLE
Implement Approx/Exact and Exp/Dec chips in top right of the main calculator screen

### DIFF
--- a/app/src/main/java/com/jherkenhoff/qalculate/domain/CalculateUseCase.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/domain/CalculateUseCase.kt
@@ -1,5 +1,6 @@
 package com.jherkenhoff.qalculate.domain
 
+import com.jherkenhoff.libqalculate.ApproximationMode
 import com.jherkenhoff.libqalculate.Calculator
 import com.jherkenhoff.libqalculate.MathStructure
 import com.jherkenhoff.qalculate.data.EvaluationOptionsRepository
@@ -11,9 +12,13 @@ class CalculateUseCase @Inject constructor(
     private val evaluationOptionsRepository: EvaluationOptionsRepository,
     private val calc: Calculator
 ) {
-    suspend operator fun invoke(expression: String): MathStructure {
+    suspend operator fun invoke(expression: String, approximationMode: ApproximationMode): MathStructure {
+        calc.setCustomAngleUnit(calc.getDegUnit())
+
         return withContext(Dispatchers.Default) {
             val evaluationOptions = evaluationOptionsRepository.getEvaluationOptions()
+
+            evaluationOptions.approximation = approximationMode
 
             val result = calc.calculate(expression, evaluationOptions)
 

--- a/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/jherkenhoff/qalculate/ui/calculator/CalculatorScreen.kt
@@ -23,15 +23,18 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jherkenhoff.libqalculate.ApproximationMode
 import com.jherkenhoff.qalculate.data.model.CalculationHistoryItem
 import kotlinx.coroutines.awaitCancellation
 import java.time.LocalDateTime
@@ -61,6 +64,8 @@ fun CalculatorScreen(
         onAutocompleteClick = viewModel::acceptAutocomplete,
         onAutocompleteDismiss = viewModel::dismissAutocomplete,
         openDrawer = openDrawer,
+        onApproximationChanged = viewModel::setApproximationMode,
+        onDisplayExponentChanged = viewModel::setMinExponent
     )
 }
 
@@ -83,7 +88,9 @@ fun CalculatorScreenContent(
     onAltKeyboardToggle: (Boolean) -> Unit = {},
     onAutocompleteClick: (String, String) -> Unit = {_, _ ->},
     onAutocompleteDismiss: () -> Unit = {  },
-    openDrawer: () -> Unit = {  }
+    openDrawer: () -> Unit = {  },
+    onApproximationChanged: (ApproximationMode) -> Unit = {  },
+    onDisplayExponentChanged: (Int) -> Unit = {  }
 ) {
 
     //val screenSettingsRepository = ScreenSettingsRepository(LocalContext.current)
@@ -111,9 +118,21 @@ fun CalculatorScreenContent(
 
                 },
                 actions = {
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("DEG") })
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("Exact") })
-                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("Exp.") })
+
+                    var isExact by rememberSaveable { mutableStateOf(false) }
+                    var isExponent by rememberSaveable { mutableStateOf(false) }
+
+                    SuggestionChip(onClick = { /*TODO*/ }, label = { Text("RAD", textDecoration = TextDecoration.LineThrough) })
+
+                    SuggestionChip(label = { Text(if(isExact) "Exact" else "Approx.") }, onClick = {
+                        isExact = !isExact
+                        onApproximationChanged(if(isExact) ApproximationMode.APPROXIMATION_EXACT else ApproximationMode.APPROXIMATION_TRY_EXACT)
+                    })
+
+                    SuggestionChip(label = { Text(if(isExponent) "Exp." else "Dec.") }, onClick = {
+                        isExponent = !isExponent
+                        onDisplayExponentChanged(if(isExponent) 1 else -1)
+                    })
                 }
 
             )


### PR DESCRIPTION
The two rightmost chips in the top right of the main calculator screen now work, allowing for choosing between exact and approximated answers (sin(2) vs. 0.9093), and decimal and exponent answers (0.00078 vs. 7.8 * 10^-4).

I'm not familiar with your codebase, so I tried to make the changes in an undisruptive manner, although please let me know if I did anything wrong.

I tried to also implement switching between radians and degrees, the third chip, but I could not get anything to work for the life of me. `Calculator.setCustomAngleUnit` did nothing, and the `libqalculator` documentation was threadbare at best. =(

<img width="864" height="1920" alt="Screenshot_20250818-211341" src="https://github.com/user-attachments/assets/27c3c1ee-a9ca-42bc-9cfb-ffea683722bf" />